### PR TITLE
Link to CDNJS instead of JSDelivr

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ There are several ways of getting PubSubJS
 * [Download a tagged version](https://github.com/mroderick/PubSubJS/tags) from GitHub
 * Install via npm (`npm install pubsub-js`)
 * Install via bower (`bower install pubsub-js`)
-* Use it via CDN directly (http://www.jsdelivr.com/#!pubsubjs)
+* Use it via CDN directly (https://cdnjs.com/libraries/pubsub-js)
 
 ## Examples
 


### PR DESCRIPTION
JSDelivr is several releases out-of-date. CDNJS is up-to-date, so let's link to that in the README instead.